### PR TITLE
Log out errors instead of returning them so the entire application doesn't explode and it's easier to find the source of the error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -275,7 +275,8 @@ var lib = createCommonjsModule(function (module, exports) {
           try {
             return reducer(draft, payload);
           } catch (error) {
-            return error
+            console.log(error)
+            return draft
           }
         });
       }

--- a/dist/index.js
+++ b/dist/index.js
@@ -272,7 +272,11 @@ var lib = createCommonjsModule(function (module, exports) {
 
       if (typeof reducer === 'function') {
         return produce(state, function (draft) {
-          return reducer(draft, payload);
+          try {
+            return reducer(draft, payload);
+          } catch (error) {
+            return error
+          }
         });
       }
 


### PR DESCRIPTION
<img width="397" alt="Screen Shot 2020-10-02 at 9 37 00 AM" src="https://user-images.githubusercontent.com/42663507/94929249-d4642000-0492-11eb-83c0-16eabf2fac09.png">
