### PR TITLE
feat: adding state types to create modules

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -136,7 +136,7 @@ export interface SagaSlice {
  *     })
  * });
  */
-export const createModule = (opts: ModuleOpts): SagaSlice => {
+export const createModule = <StoreState>(opts: ModuleOpts<StoreState>): SagaSlice => {
 
     const {
         name,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -38,13 +38,13 @@ export interface SagaObject {
     taker?: any
 }
 
-interface RequiredModuleOpts {
+interface RequiredModuleOpts<StoreState> {
     name: string,
     initialState: {
         [key: string]: any
     },
     reducers: {
-        [key: string]: () => any
+        [key: string]: (state: StoreState, payload) => void
     }
 }
 
@@ -57,7 +57,8 @@ interface OptionalModuleOpts {
     }
 };
 
-export interface ModuleOpts extends Required<RequiredModuleOpts>, OptionalModuleOpts {}
+export interface ModuleOpts<StoreState>
+  extends Required<RequiredModuleOpts<StoreState>>, OptionalModuleOpts {}
 
 interface OptsExtracts {
     actions: {


### PR DESCRIPTION
Dear All,

For the Saga Slice I have found that we cannot work with proper types in reducer. In your documentation,
`
 reducers: {
        fetch: (state) => {
            state.isFetching = true;
        },
        fetchSuccess: (state, payload) => {
            state.isFetching = false;
            state.data = payload;
        },
        fetchFail: (state, payload) => {
            state.isFetching = false;
            state.error = payload;
        }
    },
`
When I use it with Typescript it would say that fetchFail is error because the type of reducer should be `() => any`, whilst our version would be `(state: any, payload: any) => void` and would be unable to compile. Also in the long run I would prefer adding the type of state as well in the generic setting of modules then. So I modified the types of the library a bit. Please check.